### PR TITLE
serverless to use existing role; disable share-data

### DIFF
--- a/.github/workflows/share-data.yml
+++ b/.github/workflows/share-data.yml
@@ -1,9 +1,9 @@
 name: Update Shared Data
 
-on:
-  push:
-    branches:
-      - main
+# on:
+#   push:
+#     branches:
+#       - main
 
 jobs:
   share-data:

--- a/serverless.yml
+++ b/serverless.yml
@@ -14,13 +14,7 @@ provider:
   architecture: x86_64
 
   iam:
-    role:
-      # Add statements to the IAM role to give permissions to Lambda functions
-      statements:
-        - Effect: Allow
-          Action:
-            - "logs:*"
-          Resource: "*"
+    role: arn:aws:iam::202533528098:role/poprox-recommender-us-east-1-lambdaRole-prod
 
   ecr:
     # In this section you can define images that will be built locally and uploaded to ECR


### PR DESCRIPTION
1. Serverless to use existing role
2. Disable share-data on push